### PR TITLE
Add a deploy script to rsync built files to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ jekyll build
 
 The built HTML and assets are placed in the `_site` directory.
 
+### Deploying
+
+To deploy to the networkcanvas server via SSH:
+
+```
+./deploy.sh
+```
+
+If your SSH user is different than your local username, create a `.env` config
+file:
+
+```
+echo "DEPLOY_ACCOUNT=remoteuser" > .env
+```
 
 ### Directory structure
 

--- a/_config.yml
+++ b/_config.yml
@@ -46,4 +46,4 @@ livereload: true     # You no longer need to include --livereload
 reload_port: 5678    # If you don't want to use the default port
 gems:
   - jekyll-feed
-exclude: [node_modules, package.json, npm-debug.log, Gruntfile.js, Gemfile, Gemfile.lock]
+exclude: [README.md, deploy.sh,  node_modules, package.json, npm-debug.log, Gruntfile.js, Gemfile, Gemfile.lock]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Adopted from https://sookocheff.com/post/linux/deploying-a-static-site-with-rsync/
+set -o nounset
+set -o errexit
+
+DEPLOY_SOURCE_DIR="_site/"
+DEPLOY_DEST_DIR="/var/www/networkcanvas.com"
+DEPLOY_SERVER="networkcanvas.com"
+DEPLOY_ACCOUNT=`whoami`
+
+NFLAG=""
+
+while getopts ":n" opt; do
+  case $opt in
+    n)
+      NFLAG="-n"
+      echo "Dry run, not modifying server files"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
+
+# Set the environment by loading from the file "environment" in the same directory
+DIR="$( cd "$( dirname $( dirname "$0" ) )" && pwd)"
+[ -f "$DIR/.env" ] && source "$DIR/.env"
+
+echo "Building production Jekyll site"
+JEKYLL_ENV=production jekyll build
+
+echo "Deploying ${DIR}/${DEPLOY_SOURCE_DIR} to ${DEPLOY_ACCOUNT}@${DEPLOY_SERVER}:${DEPLOY_DEST_DIR}"
+rsync $NFLAG -rvz --delete -e "ssh" --rsync-path="sudo rsync" "${DIR}/${DEPLOY_SOURCE_DIR}" "${DEPLOY_ACCOUNT}@${DEPLOY_SERVER}:${DEPLOY_DEST_DIR}"


### PR DESCRIPTION
Installing Ruby on the server has been a continuous pain point, so it would be easier to build locally and push the built files up. This adds a deploy script to do this. I already pushed the corresponding changes to the ansible cookbook, it's much faster and less brittle now.